### PR TITLE
Feature: PageDataContextTagHelper

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
 		<Authors>$(Company)</Authors>
 		<Copyright>Copyright © $(Company) $([System.DateTime]::Now.Year)</Copyright>
 		<Trademark>$(Company)™</Trademark>
-		<VersionPrefix>1.0.0</VersionPrefix>
+		<VersionPrefix>1.1.0</VersionPrefix>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageProjectUrl>https://github.com/wiredviews/xperience-page-builder-utilities</PackageProjectUrl>
 		<PackageIcon>wv-logo.png</PackageIcon>

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Xperience Page Builder Utilities
 
-[![NuGet Package](https://img.shields.io/nuget/v/XperienceCommunity.PageBuilderUtilities.svg)](https://www.nuget.org/packages/XperienceCommunity.PageBuilderUtilities)
+## Packages
 
-[![NuGet Package](https://img.shields.io/nuget/v/XperienceCommunity.PageBuilderTagHelpers.svg)](https://www.nuget.org/packages/XperienceCommunity.PageBuilderTagHelpers)
+- [![NuGet Package](https://img.shields.io/nuget/v/XperienceCommunity.PageBuilderUtilities.svg)](https://www.nuget.org/packages/XperienceCommunity.PageBuilderUtilities) **XperienceCommunity.PageBuilderUtilities**
+
+- [![NuGet Package](https://img.shields.io/nuget/v/XperienceCommunity.PageBuilderTagHelpers.svg)](https://www.nuget.org/packages/XperienceCommunity.PageBuilderTagHelpers) **XperienceCommunity.PageBuilderTagHelpers**
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,16 @@ to help toggle HTML in Razor views based on the Page Builder 'mode' of the reque
      <!-- will be displayed in Edit and LivePreview modes -->
      <h1>Hello!</h1>
    </page-builder-mode>
+
+   <page-data-context> <!-- or <page-data-context initialized="true"> -->
+     <!-- will be displayed only if the IPageDataContext is popualted -->
+     <widget-zone />
+   </page-data-context>
+
+   <page-data-context initialized="false">
+     <!-- will be displayed only if the IPageDataContext is not populated -->
+     <div>widget placeholder!</div>
+   </page-data-context>
    ```
 
 ## References

--- a/XperienceCommunity.PageBuilderTagHelpers.sln
+++ b/XperienceCommunity.PageBuilderTagHelpers.sln
@@ -25,6 +25,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{E467C965-D0A7-44C6-91A8-2D983F4B9E89}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XperienceCommunity.PageBuilderUtilities.Tests", "tests\XperienceCommunity.PageBuilderUtilities.Tests\XperienceCommunity.PageBuilderUtilities.Tests.csproj", "{7936CA20-02C2-4587-89F2-37C300D312F5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -71,6 +75,18 @@ Global
 		{966625AC-777F-4DC8-931A-4865BA0C68BF}.Release|x64.Build.0 = Release|Any CPU
 		{966625AC-777F-4DC8-931A-4865BA0C68BF}.Release|x86.ActiveCfg = Release|Any CPU
 		{966625AC-777F-4DC8-931A-4865BA0C68BF}.Release|x86.Build.0 = Release|Any CPU
+		{7936CA20-02C2-4587-89F2-37C300D312F5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7936CA20-02C2-4587-89F2-37C300D312F5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7936CA20-02C2-4587-89F2-37C300D312F5}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7936CA20-02C2-4587-89F2-37C300D312F5}.Debug|x64.Build.0 = Debug|Any CPU
+		{7936CA20-02C2-4587-89F2-37C300D312F5}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7936CA20-02C2-4587-89F2-37C300D312F5}.Debug|x86.Build.0 = Debug|Any CPU
+		{7936CA20-02C2-4587-89F2-37C300D312F5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7936CA20-02C2-4587-89F2-37C300D312F5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7936CA20-02C2-4587-89F2-37C300D312F5}.Release|x64.ActiveCfg = Release|Any CPU
+		{7936CA20-02C2-4587-89F2-37C300D312F5}.Release|x64.Build.0 = Release|Any CPU
+		{7936CA20-02C2-4587-89F2-37C300D312F5}.Release|x86.ActiveCfg = Release|Any CPU
+		{7936CA20-02C2-4587-89F2-37C300D312F5}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -81,6 +97,7 @@ Global
 		{966625AC-777F-4DC8-931A-4865BA0C68BF} = {3C9B6BCE-6756-452E-8526-CFD564783488}
 		{E23E346B-6203-4FED-8304-33DF8AB9F8EA} = {7FBA6D29-D94E-484D-9BA1-3910EFE5144E}
 		{3C9B6BCE-6756-452E-8526-CFD564783488} = {7FBA6D29-D94E-484D-9BA1-3910EFE5144E}
+		{7936CA20-02C2-4587-89F2-37C300D312F5} = {E467C965-D0A7-44C6-91A8-2D983F4B9E89}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {5A1A17A7-D020-4644-AC0D-44591ED36471}

--- a/XperienceCommunity.PageBuilderTagHelpers.sln
+++ b/XperienceCommunity.PageBuilderTagHelpers.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31729.503
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.32014.148
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "XperienceCommunity.PageBuilderTagHelpers", "src\XperienceCommunity.PageBuilderTagHelpers\XperienceCommunity.PageBuilderTagHelpers.csproj", "{7CAF38B4-5C44-47FD-B79F-6AA0BDFE0522}"
 EndProject
@@ -25,9 +25,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{E467C965-D0A7-44C6-91A8-2D983F4B9E89}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XperienceCommunity.PageBuilderUtilities.Tests", "tests\XperienceCommunity.PageBuilderUtilities.Tests\XperienceCommunity.PageBuilderUtilities.Tests.csproj", "{7936CA20-02C2-4587-89F2-37C300D312F5}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "XperienceCommunity.PageBuilderUtilities.Tests", "tests\XperienceCommunity.PageBuilderUtilities.Tests\XperienceCommunity.PageBuilderUtilities.Tests.csproj", "{7936CA20-02C2-4587-89F2-37C300D312F5}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -97,7 +95,7 @@ Global
 		{966625AC-777F-4DC8-931A-4865BA0C68BF} = {3C9B6BCE-6756-452E-8526-CFD564783488}
 		{E23E346B-6203-4FED-8304-33DF8AB9F8EA} = {7FBA6D29-D94E-484D-9BA1-3910EFE5144E}
 		{3C9B6BCE-6756-452E-8526-CFD564783488} = {7FBA6D29-D94E-484D-9BA1-3910EFE5144E}
-		{7936CA20-02C2-4587-89F2-37C300D312F5} = {E467C965-D0A7-44C6-91A8-2D983F4B9E89}
+		{7936CA20-02C2-4587-89F2-37C300D312F5} = {3C9B6BCE-6756-452E-8526-CFD564783488}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {5A1A17A7-D020-4644-AC0D-44591ED36471}

--- a/src/XperienceCommunity.PageBuilderTagHelpers/PageBuilderModeTagHelper.cs
+++ b/src/XperienceCommunity.PageBuilderTagHelpers/PageBuilderModeTagHelper.cs
@@ -13,6 +13,7 @@ namespace XperienceCommunity.PageBuilderUtilities
     /// <remarks>
     /// Sourced from https://github.com/dotnet/aspnetcore/blob/v5.0.1/src/Mvc/Mvc.TagHelpers/src/EnvironmentTagHelper.cs
     /// </remarks>
+    [HtmlTargetElement("page-builder-mode")]
     public class PageBuilderModeTagHelper : TagHelper
     {
         private static readonly char[] nameSeparator = new[] { ',' };
@@ -39,12 +40,12 @@ namespace XperienceCommunity.PageBuilderUtilities
         /// <inheritdoc />
         public override void Process(TagHelperContext context, TagHelperOutput output)
         {
-            if (context == null)
+            if (context is null)
             {
                 throw new ArgumentNullException(nameof(context));
             }
 
-            if (output == null)
+            if (output is null)
             {
                 throw new ArgumentNullException(nameof(output));
             }

--- a/src/XperienceCommunity.PageBuilderTagHelpers/PageDataContextTagHelper.cs
+++ b/src/XperienceCommunity.PageBuilderTagHelpers/PageDataContextTagHelper.cs
@@ -1,0 +1,68 @@
+using System;
+using CMS.DocumentEngine;
+using Kentico.Content.Web.Mvc;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace XperienceCommunity.PageBuilderTagHelpers
+{
+    /// <summary>
+    /// <see cref="ITagHelper"/> implementation targeting &lt;page-data-context&gt; elements that conditionally renders
+    /// content based on the existance of the <see cref="IPageDataContext{TreeNode}" /> retrieved from 
+    /// <see cref="IPageDataContextRetriever"/> and the value of the <see cref="Initialized" /> attribute of the Tag Helper.
+    /// </summary>
+    [HtmlTargetElement("page-data-context")]
+    public class PageDataContextTagHelper : TagHelper
+    {
+        private readonly IPageDataContextRetriever retriever;
+
+        public PageDataContextTagHelper(IPageDataContextRetriever retriever)
+        {
+            this.retriever = retriever ?? throw new ArgumentNullException(nameof(retriever));
+        }
+
+        /// <inheritdoc />
+        public override int Order => 0;
+
+        /// <summary>
+        /// Determines whether or not the inner content of the Tag Helper is displayed.
+        /// If the <see cref="IPageDataContext{TreeNode}" /> is populated for the current request and <see cref="Initialized" />
+        /// is true or the <see cref="IPageDataContext{TreeNode}" /> is not populated and <see cref="Initialized" /> is false, the
+        /// content will be displayed. Otherwise the content will not be displayed.
+        /// </summary>
+        public bool Initialized { get; set; } = true;
+
+        /// <inheritdoc />
+        public override void Process(TagHelperContext context, TagHelperOutput output) 
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (output is null)
+            {
+                throw new ArgumentNullException(nameof(output));
+            }
+
+            // Always strip the outer tag name as we never want <page-data-context> to render
+            output.TagName = null;
+
+            if (retriever.TryRetrieve<TreeNode>(out var data))
+            {
+                if (data is object && Initialized)
+                {
+                    return;
+                }
+
+                output.SuppressOutput();
+            }
+
+            if (!Initialized)
+            {
+                return;
+            }
+
+            output.SuppressOutput();
+        }
+    }
+}

--- a/src/XperienceCommunity.PageBuilderUtilities/IPageBuilderContext.cs
+++ b/src/XperienceCommunity.PageBuilderUtilities/IPageBuilderContext.cs
@@ -6,23 +6,35 @@ namespace XperienceCommunity.PageBuilderUtilities
     public interface IPageBuilderContext
     {
         /// <summary>
-        /// True if either <see cref="IsLivePreviewMode"/> or <see cref="IsEditMode"/> is true. Also the opposite of <see cref="IsLiveMode"/>
+        /// True if either <see cref="IsLivePreviewMode"/> or <see cref="IsEditMode"/> is true. Also the opposite of <see cref="IsLiveMode"/>.
         /// </summary>
+        /// <remarks>
+        /// False if the Page Builder Mode cannot be determined (ex no HttpContext, Xperience features not initialized)
+        /// </remarks>
         bool IsPreviewMode { get; }
 
         /// <summary>
         /// True if <see cref="IsLivePreviewMode"/> and <see cref="IsEditMode"/> is false. Also the opposite of <see cref="IsPreviewMode"/>
         /// </summary>
+        /// <remarks>
+        /// True if the Page Builder Mode cannot be determined (ex no HttpContext, Xperience features not initialized)
+        /// </remarks>
         bool IsLiveMode { get; }
 
         /// <summary>
         /// True if the current request is being made for a preview version of the Page with editing disabled
         /// </summary>
+        /// <remarks>
+        /// False if the Page Builder Mode cannot be determined (ex no HttpContext, Xperience features not initialized)
+        /// </remarks>
         bool IsLivePreviewMode { get; }
 
         /// <summary>
         /// True if the current request is being made for the Page Builder experience
         /// </summary>
+        /// <remarks>
+        /// False if the Page Builder Mode cannot be determined (ex no HttpContext, Xperience features not initialized)
+        /// </remarks>
         bool IsEditMode { get; }
 
         /// <summary>

--- a/src/XperienceCommunity.PageBuilderUtilities/XperiencePageBuilderContext.cs
+++ b/src/XperienceCommunity.PageBuilderUtilities/XperiencePageBuilderContext.cs
@@ -14,13 +14,13 @@ namespace XperienceCommunity.PageBuilderUtilities
             this.accessor = accessor ?? throw new ArgumentNullException(nameof(accessor));
 
         /// <inheritdoc />
-        public bool IsPreviewMode => accessor.HttpContext.Kentico().Preview().Enabled;
+        public bool IsPreviewMode => accessor.HttpContext?.Kentico()?.Preview()?.Enabled ?? false;
 
         /// <inheritdoc />
         public bool IsLivePreviewMode => IsPreviewMode && !IsEditMode;
 
         /// <inheritdoc />
-        public bool IsEditMode => accessor.HttpContext.Kentico().PageBuilder().EditMode;
+        public bool IsEditMode => accessor.HttpContext?.Kentico()?.PageBuilder()?.EditMode ?? false;
 
         /// <inheritdoc />
         public bool IsLiveMode => !IsPreviewMode;

--- a/tests/XperienceCommunity.PageBuilderTagHelpers.Tests/PageBuilderModeTagHelperTests.cs
+++ b/tests/XperienceCommunity.PageBuilderTagHelpers.Tests/PageBuilderModeTagHelperTests.cs
@@ -34,7 +34,7 @@ namespace XperienceCommunity.PageBuilderTagHelpers.Tests
 
             var tagHelperContext = new TagHelperContext(
                 tagName: "page-builder-mode",
-                new TagHelperAttributeList { { "include", modes } },
+                new TagHelperAttributeList { },
                 new Dictionary<object, object>(),
                 Guid.NewGuid().ToString("N"));
 
@@ -73,7 +73,7 @@ namespace XperienceCommunity.PageBuilderTagHelpers.Tests
 
             var tagHelperContext = new TagHelperContext(
                 tagName: "page-builder-mode",
-                new TagHelperAttributeList { { "include", modes } },
+                new TagHelperAttributeList { },
                 new Dictionary<object, object>(),
                 Guid.NewGuid().ToString("N"));
 
@@ -114,7 +114,7 @@ namespace XperienceCommunity.PageBuilderTagHelpers.Tests
 
             var tagHelperContext = new TagHelperContext(
                 tagName: "page-builder-mode",
-                new TagHelperAttributeList { { "include", include }, { "exclude", exclude } },
+                new TagHelperAttributeList { },
                 new Dictionary<object, object>(),
                 Guid.NewGuid().ToString("N"));
 
@@ -154,7 +154,7 @@ namespace XperienceCommunity.PageBuilderTagHelpers.Tests
 
             var tagHelperContext = new TagHelperContext(
                 tagName: "page-builder-mode",
-                new TagHelperAttributeList { { "include", include }, { "exclude", exclude } },
+                new TagHelperAttributeList { },
                 new Dictionary<object, object>(),
                 Guid.NewGuid().ToString("N"));
 

--- a/tests/XperienceCommunity.PageBuilderTagHelpers.Tests/PageDataContextTagHelperTests.cs
+++ b/tests/XperienceCommunity.PageBuilderTagHelpers.Tests/PageDataContextTagHelperTests.cs
@@ -1,0 +1,176 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using CMS.DocumentEngine;
+using FluentAssertions;
+using Kentico.Content.Web.Mvc;
+using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using NSubstitute;
+using Xunit;
+
+namespace XperienceCommunity.PageBuilderTagHelpers.Tests
+{
+    public class PageDataContextTagHelperTests
+    {
+        [Fact]
+        public void Process_Will_Render_No_Content_When_There_Is_No_PageDataContext_And_Initialized_Is_True()
+        {
+            var retriever = Substitute.For<IPageDataContextRetriever>();
+
+            retriever.TryRetrieve<TreeNode>(out Arg.Any<IPageDataContext<TreeNode>>())
+                .Returns(false);
+
+            var tagHelper = new PageDataContextTagHelper(retriever)
+            {
+                Initialized = true
+            };
+
+            var tagHelperContext = new TagHelperContext(
+                tagName: "page-data-context",
+                new TagHelperAttributeList { },
+                new Dictionary<object, object>(),
+                Guid.NewGuid().ToString("N"));
+
+            var tagHelperOutput = new TagHelperOutput("page-data-context",
+                new TagHelperAttributeList(),
+                (result, encoder) =>
+                {
+                    var tagHelperContent = new DefaultTagHelperContent();
+                    tagHelperContent.SetHtmlContent(new HtmlString("<h1>Hello</h1>"));
+                    return Task.FromResult<TagHelperContent>(tagHelperContent);
+                });
+
+            tagHelper.Process(tagHelperContext, tagHelperOutput);
+
+            tagHelperOutput.TagName.Should().BeNull();
+            tagHelperOutput.IsContentModified.Should().BeTrue();
+
+            tagHelperOutput.PreElement.GetContent().Should().BeEmpty();
+            tagHelperOutput.PreContent.GetContent().Should().BeEmpty();
+            tagHelperOutput.Content.GetContent().Should().BeEmpty();
+            tagHelperOutput.PostContent.GetContent().Should().BeEmpty();
+            tagHelperOutput.PostElement.GetContent().Should().BeEmpty();
+        }
+
+        [Fact]
+        public void Process_Will_Render_Content_When_There_Is_No_PageDataContext_And_Initialized_Is_False()
+        {
+            var retriever = Substitute.For<IPageDataContextRetriever>();
+
+            retriever.TryRetrieve<TreeNode>(out Arg.Any<IPageDataContext<TreeNode>>())
+                .Returns(false);
+
+            var tagHelper = new PageDataContextTagHelper(retriever)
+            {
+                Initialized = false
+            };
+
+            var tagHelperContext = new TagHelperContext(
+                tagName: "page-data-context",
+                new TagHelperAttributeList { },
+                new Dictionary<object, object>(),
+                Guid.NewGuid().ToString("N"));
+
+            var tagHelperOutput = new TagHelperOutput("page-data-context",
+                new TagHelperAttributeList(),
+                (result, encoder) =>
+                {
+                    var tagHelperContent = new DefaultTagHelperContent();
+                    tagHelperContent.SetHtmlContent(new HtmlString("<h1>Hello</h1>"));
+                    return Task.FromResult<TagHelperContent>(tagHelperContent);
+                });
+
+            tagHelper.Process(tagHelperContext, tagHelperOutput);
+
+            tagHelperOutput.TagName.Should().BeNull();
+            tagHelperOutput.IsContentModified.Should().BeFalse();
+        }
+
+        [Fact]
+        public void Process_Will_Render_No_Content_When_There_Is_PageDataContext_And_Initialized_Is_False()
+        {
+            var retriever = Substitute.For<IPageDataContextRetriever>();
+            var context = Substitute.For<IPageDataContext<TreeNode>>();
+
+            retriever.TryRetrieve<TreeNode>(out Arg.Any<IPageDataContext<TreeNode>>())
+                .Returns(x =>
+                {
+                    x[0] = context;
+
+                    return true;
+                });
+
+            var tagHelper = new PageDataContextTagHelper(retriever)
+            {
+                Initialized = false
+            };
+
+            var tagHelperContext = new TagHelperContext(
+                tagName: "page-data-context",
+                new TagHelperAttributeList { },
+                new Dictionary<object, object>(),
+                Guid.NewGuid().ToString("N"));
+
+            var tagHelperOutput = new TagHelperOutput("page-data-context",
+                new TagHelperAttributeList(),
+                (result, encoder) =>
+                {
+                    var tagHelperContent = new DefaultTagHelperContent();
+                    tagHelperContent.SetHtmlContent(new HtmlString("<h1>Hello</h1>"));
+                    return Task.FromResult<TagHelperContent>(tagHelperContent);
+                });
+
+            tagHelper.Process(tagHelperContext, tagHelperOutput);
+
+            tagHelperOutput.TagName.Should().BeNull();
+            tagHelperOutput.IsContentModified.Should().BeTrue();
+
+            tagHelperOutput.PreElement.GetContent().Should().BeEmpty();
+            tagHelperOutput.PreContent.GetContent().Should().BeEmpty();
+            tagHelperOutput.Content.GetContent().Should().BeEmpty();
+            tagHelperOutput.PostContent.GetContent().Should().BeEmpty();
+            tagHelperOutput.PostElement.GetContent().Should().BeEmpty();
+        }
+
+        [Fact]
+        public void Process_Will_Render_Content_When_There_Is_PageDataContext_And_Initialized_Is_True()
+        {
+            var retriever = Substitute.For<IPageDataContextRetriever>();
+            var context = Substitute.For<IPageDataContext<TreeNode>>();
+
+            retriever.TryRetrieve<TreeNode>(out Arg.Any<IPageDataContext<TreeNode>>())
+                .Returns(x =>
+                {
+                    x[0] = context;
+
+                    return true;
+                });
+
+            var tagHelper = new PageDataContextTagHelper(retriever)
+            {
+                Initialized = true
+            };
+
+            var tagHelperContext = new TagHelperContext(
+                tagName: "page-data-context",
+                new TagHelperAttributeList { },
+                new Dictionary<object, object>(),
+                Guid.NewGuid().ToString("N"));
+
+            var tagHelperOutput = new TagHelperOutput("page-data-context",
+                new TagHelperAttributeList(),
+                (result, encoder) =>
+                {
+                    var tagHelperContent = new DefaultTagHelperContent();
+                    tagHelperContent.SetHtmlContent(new HtmlString("<h1>Hello</h1>"));
+                    return Task.FromResult<TagHelperContent>(tagHelperContent);
+                });
+
+            tagHelper.Process(tagHelperContext, tagHelperOutput);
+
+            tagHelperOutput.TagName.Should().BeNull();
+            tagHelperOutput.IsContentModified.Should().BeFalse();
+        }
+    }
+}

--- a/tests/XperienceCommunity.PageBuilderUtilities.Tests/XperienceCommunity.PageBuilderUtilities.Tests.csproj
+++ b/tests/XperienceCommunity.PageBuilderUtilities.Tests/XperienceCommunity.PageBuilderUtilities.Tests.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="1.3.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="NSubstitute" Version="4.2.2" />
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\XperienceCommunity.PageBuilderUtilities\XperienceCommunity.PageBuilderUtilities.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+</Project>

--- a/tests/XperienceCommunity.PageBuilderUtilities.Tests/XperiencePageBuilderContextTests.cs
+++ b/tests/XperienceCommunity.PageBuilderUtilities.Tests/XperiencePageBuilderContextTests.cs
@@ -1,0 +1,275 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using CMS.Base;
+using CMS.DocumentEngine;
+using FluentAssertions;
+using Kentico.Content.Web.Mvc;
+using Kentico.PageBuilder.Web.Mvc;
+using Kentico.Web.Mvc;
+using Microsoft.AspNetCore.Http;
+using NSubstitute;
+using NSubstitute.ReturnsExtensions;
+using XperienceCommunity.PageBuilderUtilities;
+using Xunit;
+
+namespace XperienceCommunity.PageBuilderTagHelpers.Tests
+{
+    public class XperiencePageBuilderContextTests
+    {
+        [Fact]
+        public void IsPreviewMode_Will_Be_False_If_There_Is_No_HttpContext()
+        {
+            var accessor = Substitute.For<IHttpContextAccessor>();
+
+            accessor.HttpContext.ReturnsNull();
+
+            var context = new XperiencePageBuilderContext(accessor);
+
+            context.IsPreviewMode.Should().BeFalse();
+        }
+
+        [Fact]
+        public void IsPreviewMode_Will_Be_False_If_There_Is_No_KenticoFeatures_FeatureSet()
+        {
+            var accessor = Substitute.For<IHttpContextAccessor>();
+
+            var http = Substitute.For<HttpContext>();
+            http.Items = new Dictionary<object, object>
+            {
+                { "Kentico.Features", null }
+            };
+
+            accessor.HttpContext.Returns(http);
+
+            var context = new XperiencePageBuilderContext(accessor);
+
+            context.IsPreviewMode.Should().BeFalse();
+        }
+
+        [Fact]
+        public void IsPreviewMode_Will_Be_False_If_There_Is_No_PreviewFeature_FeatureSet()
+        {
+            var accessor = Substitute.For<IHttpContextAccessor>();
+            var kenticoFeature = Substitute.For<IFeatureSet>();
+            kenticoFeature.GetFeature<IPreviewFeature>().ReturnsNull();
+
+            var http = Substitute.For<HttpContext>();
+            http.Items = new Dictionary<object, object>
+            {
+                { "Kentico.Features", kenticoFeature }
+            };
+
+            accessor.HttpContext.Returns(http);
+
+            var context = new XperiencePageBuilderContext(accessor);
+
+            context.IsPreviewMode.Should().BeFalse();
+        }
+
+        [Fact]
+        public void IsPreviewMode_Will_Be_False_If_PreviewFeature_Is_Disabled()
+        {
+            var accessor = Substitute.For<IHttpContextAccessor>();
+            var previewFeature = Substitute.For<IPreviewFeature>();
+            previewFeature.Enabled.Returns(false);
+            var kenticoFeature = Substitute.For<IFeatureSet>();
+            kenticoFeature.GetFeature<IPreviewFeature>().Returns(previewFeature);
+
+            var http = Substitute.For<HttpContext>();
+            http.Items = new Dictionary<object, object>
+            {
+                { "Kentico.Features", kenticoFeature }
+            };
+
+            accessor.HttpContext.Returns(http);
+
+            var context = new XperiencePageBuilderContext(accessor);
+
+            context.IsPreviewMode.Should().BeFalse();
+        }
+
+        [Fact]
+        public void IsPreviewMode_Will_Be_True_If_PreviewFeature_Is_Enabled()
+        {
+            var accessor = Substitute.For<IHttpContextAccessor>();
+            var previewFeature = Substitute.For<IPreviewFeature>();
+            previewFeature.Enabled.Returns(true);
+            var kenticoFeature = Substitute.For<IFeatureSet>();
+            kenticoFeature.GetFeature<IPreviewFeature>().Returns(previewFeature);
+
+            var http = Substitute.For<HttpContext>();
+            http.Items = new Dictionary<object, object>
+            {
+                { "Kentico.Features", kenticoFeature }
+            };
+
+            accessor.HttpContext.Returns(http);
+
+            var context = new XperiencePageBuilderContext(accessor);
+
+            context.IsPreviewMode.Should().BeTrue();
+        }
+
+        [Fact]
+        public void IsEditMode_Will_Be_False_If_There_Is_No_HttpContext()
+        {
+            var accessor = Substitute.For<IHttpContextAccessor>();
+
+            accessor.HttpContext.ReturnsNull();
+
+            var context = new XperiencePageBuilderContext(accessor);
+
+            context.IsEditMode.Should().BeFalse();
+        }
+
+        [Fact]
+        public void IsEditMode_Will_Be_False_If_PageBuilderFeature_Is_Not_In_EditMode()
+        {
+            var accessor = Substitute.For<IHttpContextAccessor>();
+            var pageBuilderFeature = Substitute.For<IPageBuilderFeature>();
+            pageBuilderFeature.EditMode.Returns(false);
+            var kenticoFeature = Substitute.For<IFeatureSet>();
+            kenticoFeature.GetFeature<IPageBuilderFeature>().Returns(pageBuilderFeature);
+
+            var http = Substitute.For<HttpContext>();
+            http.Items = new Dictionary<object, object>
+            {
+                { "Kentico.Features", kenticoFeature }
+            };
+
+            accessor.HttpContext.Returns(http);
+
+            var context = new XperiencePageBuilderContext(accessor);
+
+            context.IsEditMode.Should().BeFalse();
+        }
+
+        [Fact]
+        public void IsEditMode_Will_Be_True_If_PageBuidlerFeature_EditMode_Is_True()
+        {
+            var accessor = Substitute.For<IHttpContextAccessor>();
+            var pageBuilderFeature = Substitute.For<IPageBuilderFeature>();
+            pageBuilderFeature.EditMode.Returns(true);
+            var kenticoFeature = Substitute.For<IFeatureSet>();
+            kenticoFeature.GetFeature<IPageBuilderFeature>().Returns(pageBuilderFeature);
+
+            var http = Substitute.For<HttpContext>();
+            http.Items = new Dictionary<object, object>
+            {
+                { "Kentico.Features", kenticoFeature }
+            };
+
+            accessor.HttpContext.Returns(http);
+
+            var context = new XperiencePageBuilderContext(accessor);
+
+            context.IsEditMode.Should().BeTrue();
+        }
+
+        [Theory]
+        [InlineData(true, true, false)]
+        [InlineData(false, true, false)]
+        [InlineData(false, false, false)]
+        [InlineData(true, false, true)]
+        public void IsLivePreviewMode_Will_Be_True_If_EditMode_Is_False_And_PreviewMode_Is_True(
+            bool previewMode, bool editMode, bool livePreviewMode)
+        {
+            var accessor = Substitute.For<IHttpContextAccessor>();
+            var pageBuilderFeature = Substitute.For<IPageBuilderFeature>();
+            pageBuilderFeature.EditMode.Returns(editMode);
+            var previewFeature = Substitute.For<IPreviewFeature>();
+            previewFeature.Enabled.Returns(previewMode);
+            var kenticoFeature = Substitute.For<IFeatureSet>();
+            kenticoFeature.GetFeature<IPageBuilderFeature>().Returns(pageBuilderFeature);
+            kenticoFeature.GetFeature<IPreviewFeature>().Returns(previewFeature);
+
+            var http = Substitute.For<HttpContext>();
+            http.Items = new Dictionary<object, object>
+            {
+                { "Kentico.Features", kenticoFeature }
+            };
+
+            accessor.HttpContext.Returns(http);
+
+            var context = new XperiencePageBuilderContext(accessor);
+
+            context.IsLivePreviewMode.Should().Be(livePreviewMode);
+        }
+
+        [Theory]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        public void IsLiveMode_Will_Be_True_If_PreviewMode_Is_False(
+            bool previewMode, bool liveMode)
+        {
+            var accessor = Substitute.For<IHttpContextAccessor>();
+            var previewFeature = Substitute.For<IPreviewFeature>();
+            previewFeature.Enabled.Returns(previewMode);
+            var kenticoFeature = Substitute.For<IFeatureSet>();
+            kenticoFeature.GetFeature<IPreviewFeature>().Returns(previewFeature);
+
+            var http = Substitute.For<HttpContext>();
+            http.Items = new Dictionary<object, object>
+            {
+                { "Kentico.Features", kenticoFeature }
+            };
+
+            accessor.HttpContext.Returns(http);
+
+            var context = new XperiencePageBuilderContext(accessor);
+
+            context.IsLiveMode.Should().Be(liveMode);
+        }
+
+        [Fact]
+        public void Mode_Returns_The_Current_Mode()
+        {
+            var accessor = Substitute.For<IHttpContextAccessor>();
+            var pageBuilderFeature = Substitute.For<IPageBuilderFeature>();
+            pageBuilderFeature.EditMode.Returns(true);
+            var previewFeature = Substitute.For<IPreviewFeature>();
+            previewFeature.Enabled.Returns(true);
+            var kenticoFeature = Substitute.For<IFeatureSet>();
+            kenticoFeature.GetFeature<IPageBuilderFeature>().Returns(pageBuilderFeature);
+            kenticoFeature.GetFeature<IPreviewFeature>().Returns(previewFeature);
+
+            var http = Substitute.For<HttpContext>();
+            http.Items = new Dictionary<object, object>
+            {
+                { "Kentico.Features", kenticoFeature }
+            };
+
+            accessor.HttpContext.Returns(http);
+
+            var context = new XperiencePageBuilderContext(accessor);
+
+            context.Mode.Should().Be(PageBuilderMode.Edit);
+        }
+
+        [Fact]
+        public void ModeName_Returns_The_Current_Mode_As_A_String()
+        {
+            var accessor = Substitute.For<IHttpContextAccessor>();
+            var pageBuilderFeature = Substitute.For<IPageBuilderFeature>();
+            pageBuilderFeature.EditMode.Returns(true);
+            var previewFeature = Substitute.For<IPreviewFeature>();
+            previewFeature.Enabled.Returns(true);
+            var kenticoFeature = Substitute.For<IFeatureSet>();
+            kenticoFeature.GetFeature<IPageBuilderFeature>().Returns(pageBuilderFeature);
+            kenticoFeature.GetFeature<IPreviewFeature>().Returns(previewFeature);
+
+            var http = Substitute.For<HttpContext>();
+            http.Items = new Dictionary<object, object>
+            {
+                { "Kentico.Features", kenticoFeature }
+            };
+
+            accessor.HttpContext.Returns(http);
+
+            var context = new XperiencePageBuilderContext(accessor);
+
+            context.ModeName().Should().Be(nameof(PageBuilderMode.Edit));
+        }
+    }
+}


### PR DESCRIPTION
- Adds new `PageDataContextTagHelper`

```html
<page-data-context> <!-- or <page-data-context initialized="true"> -->
    <!-- will be displayed only if the IPageDataContext is popualted -->
    <widget-zone />
</page-data-context>

<page-data-context initialized="false">
    <!-- will be displayed only if the IPageDataContext is not populated -->
    <div>widget placeholder!</div>
</page-data-context>
```

- Adds tests missing for `XperiencePageBuilderContext`
- Handles `null` values in `XperiencePageBuilderContext`
- Clean up tests